### PR TITLE
.NET 5, WebView2 v90.0.818.66

### DIFF
--- a/WebView2App/WebView2App.csproj
+++ b/WebView2App/WebView2App.csproj
@@ -1,13 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="0.9.579-prerelease" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.818.41" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Prompted by [this Twitter thread](https://twitter.com/noseratio/status/1397552027329171461?s=20):

I've updated the project to use a .NET 5, WebView2 Runtime v90.0.818.66 and Microsoft.Web.WebView2 v1.0.818.41.

There's a big improvement, ~270MB now vs ~580MB I saw back then with the WebView2 preview.  Well done MSEdge team!

![image](https://user-images.githubusercontent.com/4774875/119678485-e4e26400-be82-11eb-8c7d-f22194ffdcb0.png)
